### PR TITLE
JBEAP-17931 Fix problem introduced in JAVASERVERFACES_SPEC_PUBLIC-132…

### DIFF
--- a/api/src/main/java/javax/faces/component/UIInput.java
+++ b/api/src/main/java/javax/faces/component/UIInput.java
@@ -993,9 +993,8 @@ public class UIInput extends UIOutput implements EditableValueHolder {
         // If non-null, an instanceof String, and we're configured to treat
         // zero-length Strings as null:
         //   call setSubmittedValue(null)
-        if ((considerEmptyStringNull(context)
-             && submittedValue instanceof String
-             && ((String) submittedValue).length() == 0)) {
+        boolean isEmptyStringNull = (considerEmptyStringNull(context) && submittedValue instanceof String && ((String) submittedValue).length() == 0);
+        if (isEmptyStringNull) {
             setSubmittedValue(null);
             submittedValue = null;
         }
@@ -1017,17 +1016,18 @@ public class UIInput extends UIOutput implements EditableValueHolder {
 
         // If our value is valid, store the new value, erase the
         // "submitted" value, and emit a ValueChangeEvent if appropriate
-        if (isValid()) {
-            Object previous = getValue();
+        Object previous = getValue();
+        if (isValid() && !isEmptyStringNull) {
             setValue(newValue);
             setSubmittedValue(null);
-            if (compareValues(previous, newValue)) {
-                queueEvent(new ValueChangeEvent(context, this, previous, newValue));
-            }
         } else {
             if (submittedValue == null) {
                 setSubmittedValue("");
             }
+        }
+
+        if (compareValues(previous, newValue)) {
+            queueEvent(new ValueChangeEvent(context, this, previous, newValue));
         }
 
     }


### PR DESCRIPTION
…9, also consider Submitted value  when EMPTY_STRING_AS_NULL_PARAM_NAME is enabled.

https://issues.redhat.com/browse/JBEAP-17931

This is for fix in jsf-api, I have firstly opened a PR to https://github.com/jboss/jboss-jsf-api_spec/pull/16 for 2.3.9.SP branch, but it seems that's no longer used since EAP 7.3.0. For the moment, I leave 2.3.9.SP branch opem, feel free to close if it's not needed. Thanks.

downstream for 7.2.z 2.3.5.SP branch PR https://github.com/jboss/jboss-jsf-api_spec/pull/17