### PR TITLE
JBEAP-17931 2nd part fix for TCK failure, If the component is NOT val…

### DIFF
--- a/api/src/main/java/javax/faces/component/UIInput.java
+++ b/api/src/main/java/javax/faces/component/UIInput.java
@@ -1026,7 +1026,7 @@ public class UIInput extends UIOutput implements EditableValueHolder {
             }
         }
 
-        if (compareValues(previous, newValue)) {
+        if (isValid() && compareValues(previous, newValue)) {
             queueEvent(new ValueChangeEvent(context, this, previous, newValue));
         }
 


### PR DESCRIPTION
2nd part fix for TCK failure, If the component is NOT valid, the associated ValueChangeListener must NOT be invoked

Issue: https://issues.redhat.com/browse/JBEAP-17931

Downstream jboss-jsf-api_spec 2.3.5.SP PR: https://github.com/jboss/jboss-jsf-api_spec/pull/19

Upstream eclipse-ee4j/mojarra PR: https://github.com/eclipse-ee4j/mojarra/pull/4681