### PR TITLE
Alternative 3.0.0.sp

### DIFF
--- a/api/src/main/java/javax/faces/component/UIInput.java
+++ b/api/src/main/java/javax/faces/component/UIInput.java
@@ -986,6 +986,10 @@ public class UIInput extends UIOutput implements EditableValueHolder {
             if (isRequired() && isSetAlwaysValidateRequired(context)) {
                 // continue as below
             } else {
+                if(considerEmptyStringNull(context)) {
+                    // https://github.com/eclipse-ee4j/mojarra/issues/4550
+                    validateValue(context,  getConvertedValue(context, submittedValue));
+                }
                 return;
             }
         }

--- a/api/src/main/java/javax/faces/component/UIInput.java
+++ b/api/src/main/java/javax/faces/component/UIInput.java
@@ -1026,7 +1026,7 @@ public class UIInput extends UIOutput implements EditableValueHolder {
             }
         }
 
-        if (isValid() && compareValues(previous, newValue)) {
+        if (compareValues(previous, newValue)) {
             queueEvent(new ValueChangeEvent(context, this, previous, newValue));
         }
 

--- a/api/src/main/java/javax/faces/component/UIInput.java
+++ b/api/src/main/java/javax/faces/component/UIInput.java
@@ -993,8 +993,9 @@ public class UIInput extends UIOutput implements EditableValueHolder {
         // If non-null, an instanceof String, and we're configured to treat
         // zero-length Strings as null:
         //   call setSubmittedValue(null)
-        boolean isEmptyStringNull = (considerEmptyStringNull(context) && submittedValue instanceof String && ((String) submittedValue).length() == 0);
-        if (isEmptyStringNull) {
+        if ((considerEmptyStringNull(context)
+             && submittedValue instanceof String
+             && ((String) submittedValue).length() == 0)) {
             setSubmittedValue(null);
             submittedValue = null;
         }
@@ -1016,18 +1017,17 @@ public class UIInput extends UIOutput implements EditableValueHolder {
 
         // If our value is valid, store the new value, erase the
         // "submitted" value, and emit a ValueChangeEvent if appropriate
-        Object previous = getValue();
-        if (isValid() && !isEmptyStringNull) {
+        if (isValid()) {
+            Object previous = getValue();
             setValue(newValue);
             setSubmittedValue(null);
+            if (compareValues(previous, newValue)) {
+                queueEvent(new ValueChangeEvent(context, this, previous, newValue));
+            }
         } else {
             if (submittedValue == null) {
                 setSubmittedValue("");
             }
-        }
-
-        if (compareValues(previous, newValue)) {
-            queueEvent(new ValueChangeEvent(context, this, previous, newValue));
         }
 
     }

--- a/api/src/main/java/javax/faces/component/UIViewParameter.java
+++ b/api/src/main/java/javax/faces/component/UIViewParameter.java
@@ -268,27 +268,8 @@ public class UIViewParameter extends UIInput {
             context.renderResponse();
         }
         else {
-            if (myConsiderEmptyStringNull(context)) {
-                // JAVASERVERFACES_SPEC_PUBLIC-1329: If the EMPTY_STRING_SUBMITTED_VALUES_AS_NULL
-                // config is set, ensure that logic gets a chance to be executed
-                // in UIInput.processValidators().
-                if (null == submittedValue) {
-                    setSubmittedValue("");
-                }
-            }
             super.processValidators(context);
         }
-    }
-    
-    private boolean myConsiderEmptyStringNull(FacesContext ctx) {
-
-        if (emptyStringIsNull == null) {
-            String val = ctx.getExternalContext().getInitParameter(EMPTY_STRING_AS_NULL_PARAM_NAME);
-            emptyStringIsNull = Boolean.valueOf(val);
-        }
-
-        return emptyStringIsNull;
-        
     }
     
     


### PR DESCRIPTION
issue: https://issues.redhat.com/browse/WFLY-13497
Alternative fix for community report issue https://github.com/jboss/mojarra/issues/71

impact: If context parameter `javax.faces.INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL` set to True,  then an empty value from UIInput component is not set to null any more.

reproducer: https://github.com/soul2zimate/quickstart/tree/jsf-wrong-behaviour/helloworld-jsf

workaround: Do not enable the context parameter javax.faces.INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL for the moment.

upstream PR: https://github.com/eclipse-ee4j/mojarra/pull/4706