### PR TITLE
JBEAP-26688 (7.4.z) mojarra #4260 - java.lang.IndexOutOfBoundsException: Index: 0, Size: 0 still occurs

### DIFF
--- a/api/src/main/java/javax/faces/component/AttachedObjectListHolder.java
+++ b/api/src/main/java/javax/faces/component/AttachedObjectListHolder.java
@@ -140,7 +140,7 @@ class AttachedObjectListHolder<T> implements PartialStateHolder {
                     add(restored);
                 }
             }
-        } else {
+        } else if (this.attachedObjects != null && this.attachedObjects.size() == attachedObjects.length) {
             // Assume 1:1 relation between existing attachedObjects and state
             for (int i = 0, len = attachedObjects.length; i < len; i++) {
                 T attachedObject = this.attachedObjects.get(i);


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-26688

Upstream Issue: https://github.com/eclipse-ee4j/mojarra/issues/4260
Upstream PR: https://github.com/eclipse-ee4j/mojarra/pull/5104